### PR TITLE
Fix AntiVillagerDamage always active bug

### DIFF
--- a/src/antiFarm/AntiVillagerDamage.java
+++ b/src/antiFarm/AntiVillagerDamage.java
@@ -27,6 +27,7 @@ public class AntiVillagerDamage implements Listener {
 	public void onDamageEntityByEntity(EntityDamageByEntityEvent event) {
 		if (event.isCancelled()) return;
 		if (event.getEntity() == null) return;
+		if (!J.configJ.config.getBoolean("settings.block-villager-damage")) return;
 		if (event.getEntity().getType().equals(EntityType.VILLAGER)) {
 			if (event.getDamager() == null) {
 				event.setCancelled(true);


### PR DESCRIPTION
Villagers do not get damaged regardless of config setting. Quick fix.